### PR TITLE
Add Miragejs server & TestProvider

### DIFF
--- a/web/src/api/config.tsx
+++ b/web/src/api/config.tsx
@@ -3,19 +3,24 @@ import { useMemo } from "react";
 import { ConfigInterface, SWRConfig } from "swr";
 import { useClient } from "./client";
 
-export const SwrConfigProvider: React.FC = ({ children }) => {
+type AppConfig = ConfigInterface<
+  unknown,
+  AxiosError,
+  (url: string, config: AxiosRequestConfig) => any
+>;
+
+export const SwrConfigProvider: React.FC<{
+  config?: AppConfig;
+}> = ({ config = {}, children }) => {
   const client = useClient();
-  const config: ConfigInterface<
-    unknown,
-    AxiosError,
-    (url: string, config: AxiosRequestConfig) => any
-  > = useMemo(
+
+  const value: AppConfig = useMemo(
     () => ({
-      dedupingInterval: process.env.NODE_ENV === "test" ? 0 : 2000,
       fetcher: (url, params) =>
         client.get(url, params).then((resp) => resp.data),
+      ...config,
     }),
-    [client]
+    [config, client]
   );
-  return <SWRConfig value={config}>{children}</SWRConfig>;
+  return <SWRConfig value={value}>{children}</SWRConfig>;
 };

--- a/web/src/api/useApiResult.spec.ts
+++ b/web/src/api/useApiResult.spec.ts
@@ -1,15 +1,8 @@
 import { waitFor } from "@testing-library/react";
-import { renderHook as tlRenderHook } from "@testing-library/react-hooks";
-import { createServer, Server, Response } from "miragejs";
+import { Response } from "miragejs";
 import { object, boolean, StructError } from "superstruct";
-import { cache } from "swr";
-import { AppProvider } from "../app";
+import { renderHook } from "../testing";
 import { useApiResult } from "./useApiResult";
-
-const renderHook = <P, R>(cb: (props: P) => R) =>
-  tlRenderHook<P, R>(cb, {
-    wrapper: AppProvider,
-  });
 
 const ResponseModel = object({
   success: boolean(),
@@ -18,25 +11,10 @@ const ResponseModel = object({
 const DUMMY_API = "/api/test";
 
 describe("useApiResult", () => {
-  let server: Server;
-
-  beforeEach(() => {
-    server = createServer({
-      environment: "test",
-      routes() {
-        this.get(DUMMY_API, () => ({
-          success: true,
-        }));
-      },
-    });
-  });
-
-  afterEach(async () => {
-    server?.shutdown();
-    await waitFor(() => cache.clear());
-  });
-
   it("should transition from loading -> success on successful API call", async () => {
+    server.get(DUMMY_API, () => ({
+      success: true,
+    }));
     const { result } = renderHook(() => useApiResult(DUMMY_API, ResponseModel));
 
     expect(result.current).toEqual({

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -2,4 +2,21 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+import { waitFor } from "@testing-library/react";
+import { Server } from "miragejs";
+import { cache } from "swr";
+import { createMockServer } from "./testing/server";
+
+declare global {
+  const server: Server;
+}
+
+beforeEach(() => {
+  createMockServer({ environment: "test" });
+});
+
+afterEach(async () => {
+  server.shutdown();
+  await waitFor(() => cache.clear());
+});

--- a/web/src/testing/index.ts
+++ b/web/src/testing/index.ts
@@ -1,0 +1,3 @@
+export * from "./provider";
+export * from "./render";
+export * from "./server";

--- a/web/src/testing/provider.tsx
+++ b/web/src/testing/provider.tsx
@@ -1,0 +1,15 @@
+import { HashRouter } from "react-router-dom";
+import { AuthProvider } from "../auth";
+import { SwrConfigProvider, ClientProvider } from "../api";
+
+export const TestProvider: React.FC = ({ children }) => {
+  return (
+    <HashRouter>
+      <AuthProvider>
+        <SwrConfigProvider config={{ dedupingInterval: 0 }}>
+          <ClientProvider>{children}</ClientProvider>
+        </SwrConfigProvider>
+      </AuthProvider>
+    </HashRouter>
+  );
+};

--- a/web/src/testing/render.ts
+++ b/web/src/testing/render.ts
@@ -1,0 +1,7 @@
+import { renderHook as tlRenderHook } from "@testing-library/react-hooks";
+import { TestProvider } from "./provider";
+
+export const renderHook = <P, R>(cb: (props: P) => R) =>
+  tlRenderHook<P, R>(cb, {
+    wrapper: TestProvider,
+  });

--- a/web/src/testing/server.ts
+++ b/web/src/testing/server.ts
@@ -1,0 +1,54 @@
+import { createServer, Factory, Model, RestSerializer } from "miragejs";
+import { shared } from "../config";
+
+export const createMockServer = ({ environment = "development" }) =>
+  createServer({
+    environment,
+    urlPrefix: shared.API_BASE,
+
+    serializers: {
+      application: RestSerializer,
+    },
+
+    models: {
+      user: Model,
+      meme: Model,
+    },
+
+    factories: {
+      user: Factory.extend({
+        username: "admin",
+        password: "password",
+      }),
+      meme: Factory.extend({
+        title(i: number) {
+          return `Meme ${i}`;
+        },
+
+        filename: "https://via.placeholder.com/400x600",
+      }),
+    },
+
+    seeds(server) {},
+
+    routes() {
+      this.post("/users", (schema, request) => {
+        const body = JSON.parse(request.requestBody);
+
+        return schema.db.user.insert(body);
+      });
+
+      this.post("/auth/login", (schema, request) => {
+        const body = JSON.parse(request.requestBody);
+
+        return schema.where("user", {
+          username: body.username,
+          password: body.password,
+        });
+      });
+
+      this.get("/memes", (schema) => {
+        return schema.all("meme").models;
+      });
+    },
+  });


### PR DESCRIPTION
This is now global to the entire test suite, and TestProvider configures
swr to disable its deduping. We also need to clear the cache after every
test run, so move that to a global concern as well. This should enable
the tests to run correctly & Storybook development to work as expected.