### PR TITLE
Add search to /memes endpoint

### DIFF
--- a/api/memezer/conftest.py
+++ b/api/memezer/conftest.py
@@ -53,7 +53,7 @@ def user(db: Session) -> User:
 @pytest.fixture
 def meme(db: Session, user: User) -> Meme:
     return Meme.create_meme(
-        db, meme=MemeCreate(uploader_id=user.id, filename="test-file.jpg")
+        db, meme=MemeCreate(uploader_id=user.id, filename="trollface.png")
     )
 
 

--- a/api/memezer/core/db.py
+++ b/api/memezer/core/db.py
@@ -1,8 +1,9 @@
-from typing import Generator
+from typing import Generator, Generic, TypeVar
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm.query import Query
 
 from .settings import settings
 
@@ -18,3 +19,11 @@ def get_db() -> Generator[Session, None, None]:
         yield db
     finally:
         db.close()
+
+
+Q = TypeVar("Q")
+
+
+class ModifiesQuery(Generic[Q]):
+    def modify_query(self, query: "Query[Q]") -> "Query[Q]":
+        return query

--- a/api/memezer/meme/router.py
+++ b/api/memezer/meme/router.py
@@ -8,6 +8,7 @@ from ..auth.depends import get_authed_user_id
 from ..core.db import get_db
 from .models import Meme
 from .schemas import MemeView
+from .search import MemeSearchParams
 
 router = APIRouter(
     prefix="/memes",
@@ -17,9 +18,11 @@ router = APIRouter(
 
 @router.get("", response_model=List[MemeView])
 def get_memes(
-    db: Session = Depends(get_db), user_id: UUID = Depends(get_authed_user_id)
+    db: Session = Depends(get_db),
+    user_id: UUID = Depends(get_authed_user_id),
+    search: MemeSearchParams = Depends(MemeSearchParams),
 ) -> List[Meme]:
-    return Meme.get_memes_from_uploader_id(db, user_id)
+    return Meme.get_memes_from_uploader_id(db, user_id, modifier=search)
 
 
 @router.post("", response_model=MemeView, status_code=201)

--- a/api/memezer/meme/search.py
+++ b/api/memezer/meme/search.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from sqlalchemy import or_
+from sqlalchemy.orm.query import Query
+
+from ..core.db import ModifiesQuery
+from .models import Meme
+
+
+class MemeSearchParams(ModifiesQuery[Meme]):
+    def __init__(self, term: Optional[str] = None):
+        self.term = term
+
+    def modify_query(self, query: "Query[Meme]") -> "Query[Meme]":
+        if self.term is not None:
+            query = query.filter(
+                or_(
+                    Meme.title.ilike(f"%{self.term}%"),
+                    Meme.filename.ilike(f"%{self.term}%"),
+                )
+            )
+
+        return query

--- a/api/memezer/meme/test_search.py
+++ b/api/memezer/meme/test_search.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from sqlalchemy.orm.session import Session
+
+from .models import Meme
+from .search import MemeSearchParams
+
+
+def test_should_query_title_by_term(db: Session, meme: Meme) -> None:
+    result = Meme.get_memes_from_uploader_id(
+        db, UUID(meme.uploader_id), modifier=MemeSearchParams(term="face")
+    )
+
+    assert len(result) == 1
+    assert result[0] == meme
+
+
+def test_should_return_empty_list_no_matching(db: Session, meme: Meme) -> None:
+    result = Meme.get_memes_from_uploader_id(
+        db, UUID(meme.uploader_id), modifier=MemeSearchParams(term="arrgh")
+    )
+
+    assert len(result) == 0


### PR DESCRIPTION
Add supprt for a `term` query string to the `/memes` endpoint
which will search the title & filename for the provided term with
postgres `ilike`.