### PR TITLE
Add CASCADE to DROP SCHEMA

### DIFF
--- a/api/alembic/versions/bd1318844516_add_procrastinate_schema.py
+++ b/api/alembic/versions/bd1318844516_add_procrastinate_schema.py
@@ -29,4 +29,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(f"DROP SCHEMA {settings.QUEUE_SCHEMA}")
+    op.execute(f"DROP SCHEMA {settings.QUEUE_SCHEMA} CASCADE")


### PR DESCRIPTION
Otherwise its objects won't get dropped correctly.