### PR TITLE
Fix memes constants

### DIFF
--- a/web/src/memes/constants.ts
+++ b/web/src/memes/constants.ts
@@ -1,3 +1,1 @@
-import { shared } from "../config";
-
-export const MEME_URL = `${shared.API_BASE}/memes`;
+export const MEME_URL = `/memes`;


### PR DESCRIPTION
Attaching the API_BASE as both `baseUrl` & the MEM_URL causes
the path to be added twice when the API_BASE isn't a fully qualified
URL.