### PR TITLE
Add Docker entrypoint

### DIFF
--- a/docker-compose.override.template.yml
+++ b/docker-compose.override.template.yml
@@ -5,16 +5,19 @@ services:
       - ./api:/app
       - ./web/build:/app/build
       - ./media:/media
+      - ./docker_entrypoint.sh:/docker_entrypoint.sh
 
   migrations:
     volumes:
       - ./api:/app
       - ./media:/media
+      - ./docker_entrypoint.sh:/docker_entrypoint.sh
 
   tasks:
     volumes:
       - ./api:/app
       - ./media:/media
+      - ./docker_entrypoint.sh:/docker_entrypoint.sh
 
   web:
     depends_on:

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+MEDIA_DIR="${MEDIA_DIR:-/data}"
+MEMEZER_USER="${MEMEZER_USER:-memezer}"
+
+
+# Set the memezer user UID & GID
+if [[ -n "$PUID" && "$PUID" != 0 ]]; then
+    usermod -u "$PUID" "$MEMEZER_USER" > /dev/null 2>&1
+fi
+if [[ -n "$PGID" && "$PGID" != 0 ]]; then
+    groupmod -g "$PGID" "$MEMEZER_USER" > /dev/null 2>&1
+fi
+
+# Set the permissions of the data dir to match the memezer user
+if [[ -d "$MEDIA_DIR" ]]; then
+    # Check media directory permissions
+    if [[ ! "$(stat -c %u $MEDIA_DIR)" = "$(id -u memezer)" ]]; then
+        echo "Change in ownership detected, please be patient while we chown existing files"
+        chown $MEMEZER_USER:$MEMEZER_USER -R "$MEDIA_DIR"
+    fi
+else
+    # Create media directory
+    mkdir -p "$MEDIA_DIR"
+    chown -R $MEMEZER_USER:$MEMEZER_USER "$MEDIA_DIR"
+fi
+chown $MEMEZER_USER:$MEMEZER_USER "$MEDIA_DIR"
+
+# Drop permissions to run commands as the memezer user
+if [[ "$1" == /* || "$1" == "gunicorn" || "$1" == "alembic" || "$1" == "procrastinate" || "$1" == "memezer" ]]; then
+    # arg 1 is a binary, execute it verbatim
+    exec gosu "$MEMEZER_USER" bash -c "$*"
+else
+    # no command given, assume args were meant to be passed to memezer cmd
+    exec gosu "$MEMEZER_USER" bash -c "memezer $*"
+fi


### PR DESCRIPTION
Create a memezer user in the Docker container & run the app that user,
rather than as root (which is obviously bad). Add support for
customizing that user's PUID/GUID as well as a few other env vars. Also
make sure we can run gunicorn + alembic from the entrypoint.

Fixes #125.