### PR TITLE
Add pagination

### DIFF
--- a/api/memezer/meme/models.py
+++ b/api/memezer/meme/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 from uuid import UUID, uuid4
 
 from fastapi import UploadFile
@@ -89,11 +89,14 @@ class Meme(Base):
         cls,
         db: Session,
         uploader_id: UUID,
-        modifier: Optional[ModifiesQuery[Meme]] = None,
-    ) -> List[Meme]:
+        modifiers: List[ModifiesQuery[Meme]] = [],
+    ) -> Query[Meme]:
         query = cls.get_owned_query(db, uploader_id)
-        query = modifier.modify_query(query) if modifier is not None else query
-        return query.all()
+
+        for modifier in modifiers:
+            query = modifier.modify_query(query)
+
+        return query
 
     @staticmethod
     def create_meme(db: Session, *, meme: MemeCreate) -> Meme:

--- a/api/memezer/meme/router.py
+++ b/api/memezer/meme/router.py
@@ -1,14 +1,14 @@
-from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, UploadFile
+from fastapi_pagination import Page
 from sqlalchemy.orm import Session
 
 from ..auth.depends import get_authed_user_id
 from ..core.db import get_db
 from .models import Meme
 from .schemas import MemeUpdate, MemeView
-from .search import MemeSearchParams
+from .search import MemeParams
 
 router = APIRouter(
     prefix="/memes",
@@ -16,13 +16,13 @@ router = APIRouter(
 )
 
 
-@router.get("", response_model=List[MemeView])
+@router.get("", response_model=Page[MemeView])
 def get_memes(
     db: Session = Depends(get_db),
     user_id: UUID = Depends(get_authed_user_id),
-    search: MemeSearchParams = Depends(MemeSearchParams),
-) -> List[Meme]:
-    return Meme.get_memes_owned_by(db, user_id, modifier=search)
+    params: MemeParams = Depends(MemeParams),
+) -> Page[Meme]:
+    return params.respond(db, user_id)
 
 
 @router.post("", response_model=MemeView, status_code=201)

--- a/api/memezer/meme/search.py
+++ b/api/memezer/meme/search.py
@@ -1,6 +1,12 @@
 from typing import Optional
+from uuid import UUID
 
+from fastapi import Depends
+from fastapi import Query as QueryParam
+from fastapi_pagination import Page, Params
+from fastapi_pagination.ext.sqlalchemy import paginate_query
 from sqlalchemy import or_
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
 
 from ..core.db import ModifiesQuery
@@ -8,7 +14,9 @@ from .models import Meme
 
 
 class MemeSearchParams(ModifiesQuery[Meme]):
-    def __init__(self, term: Optional[str] = None):
+    def __init__(
+        self, term: Optional[str] = QueryParam(None, description="Search term")
+    ):
         self.term = term
 
     def modify_query(self, query: "Query[Meme]") -> "Query[Meme]":
@@ -22,3 +30,37 @@ class MemeSearchParams(ModifiesQuery[Meme]):
             )
 
         return query
+
+
+class MemePageParams(ModifiesQuery[Meme]):
+    def __init__(self, params: Params = Depends(Params)):
+        self.params = params
+
+    def modify_query(self, query: "Query[Meme]") -> "Query[Meme]":
+        return paginate_query(query, self.params)
+
+
+class MemeParams:
+    def __init__(
+        self,
+        search: MemeSearchParams = Depends(MemeSearchParams),
+        page: MemePageParams = Depends(MemePageParams),
+    ):
+        self.search = search
+        self.page = page
+
+    def respond(self, db: Session, user_id: UUID) -> Page[Meme]:
+        # This isn't a great setup, but mypy isn't playing nice with paginate
+        # and we need to split up the two query modifications because we need
+        # to `count` against the un-paginated query.
+        query = Meme.get_memes_owned_by(db, user_id, modifiers=[self.search]).order_by(
+            Meme.uploaded_at.desc()
+        )
+        total = query.count()
+        items = self.page.modify_query(query).all()
+
+        return Page.create(
+            total=total,
+            items=items,
+            params=self.page.params,
+        )

--- a/api/memezer/meme/test_router.py
+++ b/api/memezer/meme/test_router.py
@@ -23,16 +23,21 @@ def test_should_return_authed_users_memes(
     response = authed_client.get("/api/memes")
 
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": str(meme.id),
-            "filename": meme.filename,
-            "title": meme.title,
-            "file_url": meme.file_url,
-            "uploaded_at": jsonable_encoder(meme.uploaded_at),
-            "accessibility_text": None,
-        }
-    ]
+    assert response.json() == {
+        "total": 1,
+        "items": [
+            {
+                "id": str(meme.id),
+                "filename": meme.filename,
+                "title": meme.title,
+                "file_url": meme.file_url,
+                "uploaded_at": jsonable_encoder(meme.uploaded_at),
+                "accessibility_text": None,
+            }
+        ],
+        "page": 0,
+        "size": 50,
+    }
 
 
 def test_should_require_auth_to_create_memes(client: TestClient) -> None:

--- a/api/memezer/meme/test_search.py
+++ b/api/memezer/meme/test_search.py
@@ -6,8 +6,8 @@ from .search import MemeSearchParams
 
 def test_should_query_title_by_term(db: Session, meme: Meme) -> None:
     result = Meme.get_memes_owned_by(
-        db, meme.uploader_id, modifier=MemeSearchParams(term="face")
-    )
+        db, meme.uploader_id, modifiers=[MemeSearchParams(term="face")]
+    ).all()
 
     assert len(result) == 1
     assert result[0] == meme
@@ -15,8 +15,8 @@ def test_should_query_title_by_term(db: Session, meme: Meme) -> None:
 
 def test_should_return_empty_list_no_matching(db: Session, meme: Meme) -> None:
     result = Meme.get_memes_owned_by(
-        db, meme.uploader_id, modifier=MemeSearchParams(term="arrgh")
-    )
+        db, meme.uploader_id, modifiers=[MemeSearchParams(term="arrgh")]
+    ).all()
 
     assert len(result) == 0
 
@@ -26,8 +26,8 @@ def test_should_search_accessibility_text(db: Session, meme: Meme) -> None:
     db.commit()
 
     result = Meme.get_memes_owned_by(
-        db, meme.uploader_id, modifier=MemeSearchParams(term="grin")
-    )
+        db, meme.uploader_id, modifiers=[MemeSearchParams(term="grin")]
+    ).all()
 
     assert len(result) == 1
     assert result[0] == meme

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.13.3
 uvloop==0.15.2
 httptools==0.1.1
 fastapi==0.63.0
+fastapi_pagination==0.7.0
 aiofiles==0.6.0
 sqlalchemy==1.3.23
 alembic==1.5.4

--- a/web/jest/setupTests.ts
+++ b/web/jest/setupTests.ts
@@ -3,8 +3,10 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
-import { banConsole } from '../src/testing'
+import { banConsole } from "../src/testing";
 
-banConsole()
+banConsole();
 
 jest.mock("../src/config");
+
+jest.spyOn(window, "scrollTo").mockImplementation(() => void 0);

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -5,7 +5,7 @@ import { Page } from "./Page";
 
 export const App = () => {
   return (
-    <Box display="flex" height="100vh" flexDirection="column">
+    <Box display="flex" minHeight="100vh" flexDirection="column">
       <Header />
       <Box component="main" flexGrow="1" display="flex" flexDirection="column">
         <Page />

--- a/web/src/home/LoggedInView.tsx
+++ b/web/src/home/LoggedInView.tsx
@@ -1,17 +1,59 @@
-import React, { useState } from "react";
-import { Box, TextField } from "@material-ui/core";
+import React, { useEffect, useMemo, useState } from "react";
+import { Box, TextField, Container } from "@material-ui/core";
 import { match } from "variant";
+import { useHistory } from "react-router";
+import { coerce, number, string, validate } from "superstruct";
 import { useMemes } from "../memes";
 import { ErrorView } from "./ErrorView";
 import { LoadingView } from "./LoadingView";
 import { SuccessView } from "./SuccessView";
+import { HOME } from "./routes";
 
-export const LoggedInView = () => {
+const PageParam = coerce(number(), string(), (value) => parseInt(value, 0));
+
+export const LoggedInView: React.FC = () => {
+  const history = useHistory();
   const [term, setTerm] = useState("");
-  const { result } = useMemes({ term });
+  const [search, setSearch] = useState(
+    // this won't trigger a rerender on its own
+    // so we keep in state & `listen` in useEffect
+    new URLSearchParams(history.location.search)
+  );
+  const pageParam = search.get("page");
+  const params = useMemo(() => {
+    const params: Parameters<typeof useMemes>[0] = {
+      // 30 works regardless of 2-across or 3-across
+      size: 30,
+    };
+
+    if (term) {
+      params.term = term;
+    }
+
+    const results = validate(pageParam, PageParam, { coerce: true });
+
+    if (results[1]) {
+      params.page = Math.max(results[1] - 1, 0);
+    }
+
+    return params;
+  }, [pageParam, term]);
+  const { result } = useMemes(params);
+
+  useEffect(() => {
+    const unregister = history.listen((location) => {
+      setSearch(new URLSearchParams(location.search));
+    });
+
+    return () => unregister();
+  }, [history]);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pageParam]);
 
   return (
-    <>
+    <Container>
       <Box mb={2}>
         <TextField
           id="term"
@@ -23,9 +65,23 @@ export const LoggedInView = () => {
       </Box>
       {match(result, {
         loading: () => <LoadingView />,
-        success: ({ data: memes }) => <SuccessView memes={memes} />,
+        success: ({ data }) => (
+          <SuccessView
+            memes={data.items}
+            page={params.page ? params.page + 1 : 1}
+            totalPages={Math.ceil(data.total / data.size)}
+            onPage={(page) => {
+              history.push({
+                pathname: `${HOME}`,
+                search: `?${new URLSearchParams({
+                  page: String(page),
+                }).toString()}`,
+              } as any);
+            }}
+          />
+        ),
         error: ({ error }) => <ErrorView error={error} />,
       })}
-    </>
+    </Container>
   );
 };

--- a/web/src/home/SuccessView.tsx
+++ b/web/src/home/SuccessView.tsx
@@ -8,15 +8,22 @@ import {
   CardContent,
   CardActions,
   Button,
+  Container,
 } from "@material-ui/core";
+import { Pagination } from "@material-ui/lab";
 import { Link } from "react-router-dom";
-import { MemeListView } from "../memes";
+import { MemeView } from "../memes";
 import { UPLOAD } from "../upload";
 import { EDIT } from "../edit";
 import { MainLink } from "./MainLink";
 import { useMediaStyles } from "./styles";
 
-export const SuccessView: React.FC<{ memes: MemeListView }> = ({ memes }) => {
+export const SuccessView: React.FC<{
+  page: number;
+  totalPages: number;
+  memes: MemeView[];
+  onPage: (page: number) => void;
+}> = ({ page, totalPages, memes, onPage }) => {
   const classes = useMediaStyles();
 
   if (memes.length === 0) {
@@ -36,29 +43,39 @@ export const SuccessView: React.FC<{ memes: MemeListView }> = ({ memes }) => {
   }
 
   return (
-    <Grid container spacing={2} data-testid="home-success">
-      {memes.map((meme) => (
-        <Grid key={meme.id} item xs={6} md={4}>
-          <Card>
-            <CardMedia image={meme.file_url} className={classes.media} />
-            <CardContent>
-              <Typography component="h3" variant="h4">
-                {meme.title}
-              </Typography>
-            </CardContent>
-            <CardActions disableSpacing>
-              <Button
-                size="small"
-                color="primary"
-                component={Link}
-                to={EDIT.replace(":memeId", meme.id)}
-              >
-                Edit
-              </Button>
-            </CardActions>
-          </Card>
-        </Grid>
-      ))}
-    </Grid>
+    <Box display="flex" flexDirection="column">
+      <Grid container spacing={2} data-testid="home-success">
+        {memes.map((meme) => (
+          <Grid key={meme.id} item xs={6} md={4}>
+            <Card>
+              <CardMedia image={meme.file_url} className={classes.media} />
+              <CardContent>
+                <Typography component="h3" variant="h4">
+                  {meme.title}
+                </Typography>
+              </CardContent>
+              <CardActions disableSpacing>
+                <Button
+                  size="small"
+                  color="primary"
+                  component={Link}
+                  to={EDIT.replace(":memeId", meme.id)}
+                >
+                  Edit
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+      <Box display="flex" justifyContent="center" mt={1} py={3}>
+        <Pagination
+          page={page}
+          count={totalPages}
+          onChange={(_, page) => onPage(page)}
+          color="primary"
+        />
+      </Box>
+    </Box>
   );
 };

--- a/web/src/home/View.tsx
+++ b/web/src/home/View.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container } from "@material-ui/core";
+import { Box } from "@material-ui/core";
 import { useClient } from "../api";
 import { LoggedInView } from "./LoggedInView";
 import { LoggedOutView } from "./LoggedOutView";
@@ -7,9 +7,5 @@ import { LoggedOutView } from "./LoggedOutView";
 export const View: React.FC = () => {
   const { isAuthenticated } = useClient();
 
-  return (
-    <Container>
-      {isAuthenticated ? <LoggedInView /> : <LoggedOutView />}
-    </Container>
-  );
+  return <Box>{isAuthenticated ? <LoggedInView /> : <LoggedOutView />}</Box>;
 };

--- a/web/src/memes/schemas.ts
+++ b/web/src/memes/schemas.ts
@@ -6,8 +6,18 @@ import {
   string,
   coerce,
   nullable,
+  Struct,
+  number,
 } from "superstruct";
 import { parseISO } from "date-fns";
+
+const Page = <T, S>(itemSchema: Struct<T, S>) =>
+  object({
+    total: number(),
+    items: array(itemSchema),
+    page: number(),
+    size: number(),
+  });
 
 export const MemeView = object({
   id: string(),
@@ -18,11 +28,12 @@ export const MemeView = object({
   accessibility_text: nullable(string()),
 });
 
+// eslint-disable-next-line
 export type MemeView = Infer<typeof MemeView>;
 
-export const MemeListView = array(MemeView);
+export const MemeCollectionView = Page(MemeView);
 
 // eslint-disable-next-line
-export type MemeListView = Infer<typeof MemeListView>;
+export type MemeCollectionView = Infer<typeof MemeCollectionView>;
 
 export type MemeUpdate = Pick<MemeView, "accessibility_text" | "title">;

--- a/web/src/memes/useMemes.spec.ts
+++ b/web/src/memes/useMemes.spec.ts
@@ -12,7 +12,7 @@ describe("useMemes", () => {
       expect(result.current).toEqual({
         result: {
           type: "success",
-          data: [],
+          data: { total: 0, size: 50, page: 0, items: [] },
         },
         uploadMeme: expect.any(Function),
       })
@@ -28,16 +28,21 @@ describe("useMemes", () => {
       expect(result.current).toEqual({
         result: {
           type: "success",
-          data: [
-            {
-              id: meme.id,
-              title: meme.title,
-              filename: meme.filename,
-              file_url: meme.file_url,
-              uploaded_at: expect.any(Date),
-              accessibility_text: null,
-            },
-          ],
+          data: {
+            total: 1,
+            size: 50,
+            page: 0,
+            items: [
+              {
+                id: meme.id,
+                title: meme.title,
+                filename: meme.filename,
+                file_url: meme.file_url,
+                uploaded_at: expect.any(Date),
+                accessibility_text: null,
+              },
+            ],
+          },
         },
         uploadMeme: expect.any(Function),
       })
@@ -52,7 +57,7 @@ describe("useMemes", () => {
       expect(result.current).toEqual({
         result: {
           type: "success",
-          data: [],
+          data: { total: 0, size: 50, page: 0, items: [] },
         },
         uploadMeme: expect.any(Function),
       })
@@ -74,16 +79,21 @@ describe("useMemes", () => {
       expect(result.current).toEqual({
         result: {
           type: "success",
-          data: [
-            {
-              id: meme.id,
-              title: filename,
-              filename,
-              file_url: meme.file_url,
-              uploaded_at: expect.any(Date),
-              accessibility_text: null,
-            },
-          ],
+          data: {
+            total: 1,
+            size: 50,
+            page: 0,
+            items: [
+              {
+                id: meme.id,
+                title: filename,
+                filename,
+                file_url: meme.file_url,
+                uploaded_at: expect.any(Date),
+                accessibility_text: null,
+              },
+            ],
+          },
         },
         uploadMeme: expect.any(Function),
       });

--- a/web/src/memes/useMemes.ts
+++ b/web/src/memes/useMemes.ts
@@ -1,17 +1,20 @@
 import { useCallback } from "react";
 import { useApiResult, useClient } from "../api";
-import { MemeListView } from "./schemas";
+import { MemeCollectionView } from "./schemas";
 import { MEME_URL } from "./constants";
 
-type SearchOptions = {
+type MemeParams = {
   term?: string;
+  page?: number;
+  size?: number;
 };
 
-export const useMemes = ({ term }: SearchOptions = {}) => {
+export const useMemes = (params: MemeParams = {}) => {
   const { api } = useClient();
   const { result, mutate } = useApiResult(
-    `${MEME_URL}${term ? `?term=${encodeURIComponent(term)}` : ""}`,
-    MemeListView
+    // @ts-expect-error search params works w/ a number but TS whines
+    `${MEME_URL}?${new URLSearchParams(params)}`,
+    MemeCollectionView
   );
 
   const uploadMeme = useCallback(
@@ -20,10 +23,15 @@ export const useMemes = ({ term }: SearchOptions = {}) => {
       formData.append("file", file);
       const response = await api.post(MEME_URL, formData);
 
-      mutate([
-        ...(result.type === "success" ? result.data : []),
-        response.data,
-      ]);
+      mutate({
+        ...(result.type === "success"
+          ? result.data
+          : { total: 1, page: 0, size: 1 }),
+        items: [
+          response.data,
+          ...(result.type === "success" ? result.data.items : []),
+        ],
+      });
     },
     [api, mutate, result]
   );

--- a/web/src/testing/server.ts
+++ b/web/src/testing/server.ts
@@ -68,7 +68,14 @@ export const createMockServer = ({
       });
 
       this.get("/memes", (schema) => {
-        return schema.all("meme").models;
+        const { models } = schema.all("meme");
+
+        return {
+          total: models.length,
+          items: models,
+          size: 50,
+          page: 0,
+        };
       });
 
       this.post("/memes", (schema, request) => {


### PR DESCRIPTION
Update API with `fastapi_pagination` to paginate the memes view. Update
the front-end to take advantage of this feature to split up the view into
30-meme pages.

Fixes #151.